### PR TITLE
#content to fit height, append logs instead of prepend

### DIFF
--- a/lib/index.html
+++ b/lib/index.html
@@ -8,8 +8,7 @@
       p { margin-bottom: 4px; }
       div { width:500px; margin-left:auto; margin-right:auto;}
       #content { padding:5px; background:#ddd; border-radius:5px;
-          overflow-y: scroll; border:1px solid #CCC;
-          margin-top:5px; height: 800px; width: 95%; }
+          border:1px solid #CCC; margin-top:5px; height: 100%; width: 95%; }
       #status { width:88px;display:block;float:left;margin-top:15px; }
     </style>
 
@@ -51,7 +50,7 @@
                 line = line.trim();
               }
               if (line.length > 0) {
-                $('#content').prepend('<p>' + line + '</p>');
+                $('#content').append('<p>' + line + '</p>');
               }
             });
           };


### PR DESCRIPTION
Let me know if you fancy this minor change.

**Changes:**
1. Adds new logs in reverse order so the latest is always on top, this means you don't have to keep scrolling down
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/889696/46920844-6ea3d280-cff4-11e8-8254-426791881c85.png">
2. Sets height of `#content` to 100% so there's only one scrollbar and not  two
